### PR TITLE
Improve select behavior

### DIFF
--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -45,10 +45,15 @@ export default class Select extends React.Component {
     document.body.addEventListener('mouseup', this.handleOutsideClick, { passive: true })
     this.props.onClick()
   }
-  setClose = () => {
-    this.setState({ open: false })
-    document.body.removeEventListener('mouseup', this.handleOutsideClick)
-    this.props.onClick()
+
+  setClose = (event) => {
+    if (!this.props.autoclose && this.container.contains(event.target)) {
+      this.handleOutsideClick
+    } else {
+      this.setState({ open: false })
+      document.body.removeEventListener('mouseup', this.handleOutsideClick)
+      this.props.onClick()
+    }
   }
 
   handleClick = event => {
@@ -56,13 +61,13 @@ export default class Select extends React.Component {
     if (!open) {
       this.setOpen()
     } else {
-      this.setClose()
+      this.setClose(event)
     }
   }
 
   handleOutsideClick = event => {
     if (this.container.contains(event.target)) return
-    this.setClose()
+    this.setClose(event)
   }
 
   render() {

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -100,12 +100,12 @@ export default class Select extends React.Component {
         className="relative"
       >
 
-        <button onClick={this.handleClick} className={classes} style={style}>
+        <div id="select-wrapper" onClick={this.handleClick} className={classes} style={style}>
           <span>{label}</span>
           <div className={`ml3 ${open ? 'rotate-180' : ''}`}>
             <DropdownSvg style={{ width: 10, height: 10, fill: dark ? 'white' : 'black' }} />
           </div>
-        </button>
+        </div>
 
         <div className={childrenClasses}>
           {scrollable ? (

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -38,22 +38,14 @@ export default class Select extends React.Component {
     open: this.props.open,
   }
 
-  container = null
-
-  setOpen = () => {
-    this.setState({ open: true })
+  componentDidMount() {
     document.body.addEventListener('mouseup', this.handleOutsideClick, { passive: true })
-    this.props.onClick()
+    document.body.addEventListener('touchend', this.handleOutsideClick, { passive: true })
   }
 
-  setClose = (event) => {
-    if (!this.props.autoclose && this.container.contains(event.target)) {
-      return null
-    } else {
-      this.setState({ open: false })
-      document.body.removeEventListener('mouseup', this.handleOutsideClick)
-      this.props.onClick()
-    }
+  componentWillUnmount() {
+    document.body.removeEventListener('mouseup', this.handleOutsideClick)
+    document.body.removeEventListener('touchend', this.handleOutsideClick)
   }
 
   handleClick = event => {

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -48,7 +48,7 @@ export default class Select extends React.Component {
 
   setClose = (event) => {
     if (!this.props.autoclose && this.container.contains(event.target)) {
-      this.handleOutsideClick
+      return null
     } else {
       this.setState({ open: false })
       document.body.removeEventListener('mouseup', this.handleOutsideClick)

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -56,10 +56,14 @@ export default class Select extends React.Component {
 
   handleClick = event => {
     const { open } = this.state
+    const { autoclose } = this.props
+
     if (!open) {
       this.setOpen()
+    } else if (autoclose) {
+      this.setClose()
     } else {
-      this.setClose(event)
+      this.props.onClick(event)
     }
   }
 

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -38,21 +38,31 @@ export default class Select extends React.Component {
     open: this.props.open,
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.open !== this.state.open) {
-      this.setState({ open: nextProps.open })
-    }
-  }
+  container = null
 
-  handleClick = event => {
-    this.setState({ open: !this.state.open })
+  setOpen = () => {
+    this.setState({ open: true })
+    document.body.addEventListener('mouseup', this.handleOutsideClick, { passive: true })
+    this.props.onClick()
+  }
+  setClose = () => {
+    this.setState({ open: false })
+    document.body.removeEventListener('mouseup', this.handleOutsideClick)
     this.props.onClick()
   }
 
-  closePanel = () => {
-    if (this.props.autoclose) {
-      this.setState({ open: !this.state.open })
+  handleClick = event => {
+    const { open } = this.state
+    if (!open) {
+      this.setOpen()
+    } else {
+      this.setClose()
     }
+  }
+
+  handleOutsideClick = event => {
+    if (this.container.contains(event.target)) return
+    this.setClose()
   }
 
   render() {
@@ -80,18 +90,23 @@ export default class Select extends React.Component {
     })
 
     return (
-      <div className="relative">
-        <div onClick={this.handleClick} className={classes} style={style}>
-          <div>{label}</div>
+      <div
+        ref={el => { this.container = el }}
+        className="relative"
+      >
+
+        <button onClick={this.handleClick} className={classes} style={style}>
+          <span>{label}</span>
           <div className={`ml3 ${open ? 'rotate-180' : ''}`}>
             <DropdownSvg style={{ width: 10, height: 10, fill: dark ? 'white' : 'black' }} />
           </div>
-        </div>
+        </button>
+
         <div className={childrenClasses}>
           {scrollable ? (
             <Scrollbars className="h-100">
               {children.map((child, i) => (
-                <div key={i} onClick={this.closePanel}>
+                <div key={i} onClick={this.handleClick}>
                   {child}
                 </div>
               ))}
@@ -99,7 +114,7 @@ export default class Select extends React.Component {
           ) : (
             open &&
             children.map((child, i) => (
-              <div key={i} onClick={this.closePanel}>
+              <div key={i} onClick={this.handleClick}>
                 {child}
               </div>
             ))

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -102,7 +102,7 @@ export default class Select extends React.Component {
         className="relative"
       >
 
-        <div id="select-wrapper" onClick={this.handleClick} className={classes} style={style}>
+        <div onClick={this.handleClick} className={classes} style={style}>
           <span>{label}</span>
           <div className={`ml3 ${open ? 'rotate-180' : ''}`}>
             <DropdownSvg style={{ width: 10, height: 10, fill: dark ? 'white' : 'black' }} />

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -48,6 +48,12 @@ export default class Select extends React.Component {
     document.body.removeEventListener('touchend', this.handleOutsideClick)
   }
 
+  container = null
+
+  setOpen = () => this.setState({ open: true })
+
+  setClose = () => this.setState({ open: false })
+
   handleClick = event => {
     const { open } = this.state
     if (!open) {


### PR DESCRIPTION
Add new feature to Select component. 
Now, when clicking outside the Select, it should close the dropdown, only if the dropdown does not contain checkboxes; in that case, the user should be able to check them without have to reopen the dropdown each time some value is checked.