### PR TITLE
Allow custom props for every component

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -14,6 +14,7 @@ export default class Button extends React.Component {
     onClick: PropTypes.func,
     className: PropTypes.string,
     style: PropTypes.object,
+    type: PropTypes.string,
   }
 
   static defaultProps = {
@@ -22,10 +23,11 @@ export default class Button extends React.Component {
     className: '',
     style: {},
     onClick: () => {},
+    type: 'button',
   }
 
   render() {
-    const { children, disabled, transparent, onClick, className, style } = this.props
+    const { children, disabled, transparent, onClick, className, style, type } = this.props
     const classes = classNames(
       'flex justify-center items-center pointer ph3 pv1 br1 outline-transparent',
       {
@@ -37,7 +39,7 @@ export default class Button extends React.Component {
     )
 
     return (
-      <button disabled={disabled} className={classes} style={style} onClick={onClick}>
+      <button disabled={disabled} className={classes} style={style} onClick={onClick} type={type}>
         {children}
       </button>
     )

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
+import { omit } from 'lodash'
 
 const disabledStyle = 'o-50 pointer-events-none'
 const defaultStyle = 'bg-black white b--none'
@@ -28,6 +29,7 @@ export default class Button extends React.Component {
 
   render() {
     const { children, disabled, transparent, onClick, className, style, type } = this.props
+
     const classes = classNames(
       'flex justify-center items-center pointer ph3 pv1 br1 outline-transparent',
       {
@@ -38,8 +40,17 @@ export default class Button extends React.Component {
       }
     )
 
+    const props = omit(this.props, Object.keys(Button.propTypes))
+
     return (
-      <button disabled={disabled} className={classes} style={style} onClick={onClick} type={type}>
+      <button
+        {...props}
+        disabled={disabled}
+        className={classes}
+        style={style}
+        onClick={onClick}
+        type={type}
+      >
         {children}
       </button>
     )

--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
+import { omit } from 'lodash'
 
 const disabledStyle = 'o-30 pointer-events-none'
 const inactiveStyle = 'o-50'
@@ -71,6 +72,8 @@ export default class Checkbox extends React.Component {
       }
     )
 
+    const props = omit(this.props, Object.keys(Checkbox.propTypes))
+
     return (
       <div style={style} className={classes} onClick={this.handleChange}>
         <div
@@ -80,6 +83,7 @@ export default class Checkbox extends React.Component {
             height: 18,
           }}>
           <input
+            {...props}
             className={inputClasses}
             type="checkbox"
             checked={checked}

--- a/src/components/FlexView/index.js
+++ b/src/components/FlexView/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import omit from 'lodash/omit'
+import { omit } from 'lodash'
 
 export default class FlexView extends React.Component {
   static propTypes = {

--- a/src/components/Radio/index.js
+++ b/src/components/Radio/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
+import { omit } from 'lodash'
 
 const disabledStyle = 'o-30 pointer-events-none'
 const inactiveStyle = 'o-50'
@@ -40,6 +41,8 @@ export default class Radio extends React.Component {
       [inputClassName]: inputClassName,
     })
 
+    const props = omit(this.props, Object.keys(Radio.propTypes))
+
     return (
       <div className={classes} style={style} onClick={this.handleClick}>
         <div
@@ -49,6 +52,7 @@ export default class Radio extends React.Component {
             height: 18,
           }}>
           <input
+            {...props}
             className={`${inputClasses} input-reset ba br-100 bw1 outline-transparent pointer`}
             type="radio"
             checked={checked}

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { Scrollbars } from 'react-custom-scrollbars'
+import { omit } from 'lodash'
 
 const disabledStyle = 'o-50 pointer-events-none'
 
@@ -96,8 +97,11 @@ export default class Select extends React.Component {
       [childrenClassName]: childrenClassName,
     })
 
+    const props = omit(this.props, Object.keys(Select.propTypes))
+
     return (
       <div
+        {...props}
         ref={el => { this.container = el }}
         className="relative"
       >

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import omit from 'lodash/omit'
+import { omit } from 'lodash'
 
 const disabledStyle = 'o-50 pointer-events-none'
 


### PR DESCRIPTION
This allows to pass every prop down to the component, such as `name`, `required`, `tabIndex`, `type` for the button or any `data-` prop.

Also this PR sets the `type` prop of the button with a default value of `button` instead of `submit`, otherwise it always submits the form it's inside on click.