### PR TITLE
Radio updates

### DIFF
--- a/src/components/Radio/README.md
+++ b/src/components/Radio/README.md
@@ -8,11 +8,11 @@ const changeSelected = (item) => (value) => {
 <FlexView column vAlign="around" className="h5">
     <p>Selected: {state.selected}</p>
 
-    <Radio onClick={changeSelected(1)} checked={state.selected === 1}>
+    <Radio onChange={changeSelected(1)} checked={state.selected === 1}>
       Click me
     </Radio>
 
-    <Radio onClick={changeSelected(2)} checked={state.selected === 2} className="blue" inputClassName="bg-blue b--blue">
+    <Radio onChange={changeSelected(2)} checked={state.selected === 2} className="blue" inputClassName="bg-blue b--blue">
       Colorful Radio
     </Radio>
 

--- a/src/components/Radio/index.js
+++ b/src/components/Radio/index.js
@@ -5,6 +5,7 @@ import { omit } from 'lodash'
 
 const disabledStyle = 'o-30 pointer-events-none'
 const inactiveStyle = 'o-50'
+const defaultInputStyle = 'bw1 b--black bg-black outline-transparent'
 
 export default class Radio extends React.Component {
   static propTypes = {
@@ -14,52 +15,57 @@ export default class Radio extends React.Component {
     style: PropTypes.object,
     disabled: PropTypes.bool,
     checked: PropTypes.bool,
-    onClick: PropTypes.func,
+    onChange: PropTypes.func,
+    reset: PropTypes.bool,
   }
 
   static defaultProps = {
     className: '',
     inputClassName: '',
     style: {},
-    onClick: () => {},
+    checked: false,
+    onChange: () => {},
+    reset: false,
   }
 
-  handleClick = () => {
-    this.props.onClick()
+  handleChange = event => {
+    this.props.onChange(event.currentTarget.checked)
   }
 
   render() {
-    const { children, className, inputClassName, style, disabled, checked } = this.props
+    const { children, className, inputClassName, style, disabled, checked, reset } = this.props
 
-    const classes = classNames('flex flex-row justify-start items-center w-fit pointer', {
+    const classes = classNames(className, 'flex items-center w-fit pointer', {
       [disabledStyle]: disabled,
-      [inactiveStyle]: !checked,
-      [className]: className,
+      [inactiveStyle]: !checked && !reset,
     })
 
-    const inputClasses = classNames('absolute absolute--fill center bg-black', {
-      [inputClassName]: inputClassName,
+    const inputClasses = classNames(inputClassName, 'absolute absolute--fill center ba', {
+      [defaultInputStyle]: !reset,
     })
 
     const props = omit(this.props, Object.keys(Radio.propTypes))
 
     return (
-      <div className={classes} style={style} onClick={this.handleClick}>
+      <label className={classes} style={style}>
         <div
           className="relative"
           style={{
             width: 18,
             height: 18,
-          }}>
+          }}
+        >
           <input
             {...props}
-            className={`${inputClasses} input-reset ba br-100 bw1 outline-transparent pointer`}
+            className={`${inputClasses} input-reset br-100 pointer`}
             type="radio"
             checked={checked}
-            readOnly
+            onChange={this.handleChange}
             style={{
               width: 18,
               height: 18,
+              // This is here to override the custom `bg-something` you can pass to the input,
+              // since it will affect also the circle on the inside
               backgroundColor: 'white',
             }}
           />
@@ -73,8 +79,8 @@ export default class Radio extends React.Component {
             />
           )}
         </div>
-        {children && <label className="ml2 pointer">{children}</label>}
-      </div>
+        {children && <div className="ml2 pointer">{children}</div>}
+      </label>
     )
   }
 }


### PR DESCRIPTION
This PR adds some changes and refactor to the component Radio:

- adds the `reset` prop
- replaces the onClick prop with the onChange following the [react standard](https://reactjs.org/docs/forms.html)
- wraps the component inside a `<label>` so it's selectable from the label