### PR TITLE
Fix Select not triggering onClick in children options

### DIFF
--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -94,6 +94,7 @@ export default class Select extends React.Component {
     })
 
     const childrenClasses = classNames(childrenClassName, 'absolute z-5', {
+      dn: !open,
       'w-100': scrollable,
       h5: open && scrollable,
       [defaultChildrenStyle]: !reset,
@@ -115,25 +116,23 @@ export default class Select extends React.Component {
             <DropdownSvg style={{ width: 10, height: 10, fill: dark ? 'white' : 'black' }} />
           </div>
         </div>
-        {open && (
-          <div className={childrenClasses}>
-            {scrollable ? (
-              <Scrollbars className="h-100">
-                {React.Children.map(children, (child, i) => (
-                  <div key={i} onClick={autoclose ? this.setClose : null}>
-                    {child}
-                  </div>
-                ))}
-              </Scrollbars>
-            ) : (
-              React.Children.map(children, (child, i) => (
+        <div className={childrenClasses}>
+          {scrollable ? (
+            <Scrollbars className="h-100">
+              {React.Children.map(children, (child, i) => (
                 <div key={i} onClick={autoclose ? this.setClose : null}>
                   {child}
                 </div>
-              ))
-            )}
-          </div>
-        )}
+              ))}
+            </Scrollbars>
+          ) : (
+            React.Children.map(children, (child, i) => (
+              <div key={i} onClick={autoclose ? this.setClose : null}>
+                {child}
+              </div>
+            ))
+          )}
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
With `open &&` on the children of the Select the onClick events on children were not registered, this is because the select removes the children from the tree as soon as you click a child.

Now with `dn` they are not removed from the tree but just hidden with css, and eventual click events still work