### PR TITLE
🗽 Toggle improvements

### DIFF
--- a/src/commons/interfaces.ts
+++ b/src/commons/interfaces.ts
@@ -9,6 +9,7 @@ export interface InputPropsTypes {
   checked?: boolean
   onChange?: (event: boolean) => void // This has to be fixed
   reset?: boolean
+  invert?: string
 }
 
 export const InputDefaultProps: object = {

--- a/src/commons/interfaces.ts
+++ b/src/commons/interfaces.ts
@@ -9,7 +9,7 @@ export interface InputPropsTypes {
   checked?: boolean
   onChange?: (event: boolean) => void // This has to be fixed
   reset?: boolean
-  invert?: string
+  invertColor?: string
 }
 
 export const InputDefaultProps: object = {

--- a/src/components/Toggle/README.md
+++ b/src/components/Toggle/README.md
@@ -1,7 +1,8 @@
 ```jsx
 initialState = {
   first: false,
-  second: true
+  second: true,
+  third: true
 }
 
 const changeSelected = (item) => (value) => {
@@ -14,6 +15,10 @@ const changeSelected = (item) => (value) => {
   <Toggle onChange={changeSelected('first')} checked={state.first}>Toggle me</Toggle>
 
   <Toggle onChange={changeSelected('second')} checked={state.second} className="red" inputClassName="bg-red">
+    Colorful Toggle
+  </Toggle>
+
+  <Toggle onChange={changeSelected('third')} checked={state.third} className="blue" invert="bg-blue">
     Colorful Toggle
   </Toggle>
 

--- a/src/components/Toggle/README.md
+++ b/src/components/Toggle/README.md
@@ -18,7 +18,7 @@ const changeSelected = (item) => (value) => {
     Colorful Toggle
   </Toggle>
 
-  <Toggle onChange={changeSelected('third')} checked={state.third} className="blue" invert="bg-blue">
+  <Toggle onChange={changeSelected('third')} checked={state.third} className="blue" invertColor="bg-blue">
     Colorful Toggle
   </Toggle>
 

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -18,7 +18,7 @@ export const Toggle: React.SFC<InputPropsTypes> = ({
   onChange = () => {},
   reset = false,
   invert = '',
-}: InputPropsTypes) => {
+}) => {
   function handleChange(event: React.ChangeEvent<HTMLInputElement>): void {
     onChange(event.currentTarget.checked)
   }

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -6,7 +6,9 @@ const disabledStyle = 'o-30 pointer-events-none'
 const inactiveStyle = 'o-50'
 const defaultInputStyle = 'br4 bg-black'
 
-export default function Toggle({
+const invertInputStyle = (invert: string) => `ba br4 bg-transparent b--${invert.replace(/bg-/, '')}`
+
+export const Toggle: React.SFC<InputPropsTypes> = ({
   children,
   className = '',
   inputClassName = '',
@@ -15,7 +17,8 @@ export default function Toggle({
   checked = false,
   onChange = () => {},
   reset = false,
-}: InputPropsTypes): JSX.Element {
+  invert = '',
+}: InputPropsTypes) => {
   function handleChange(event: React.ChangeEvent<HTMLInputElement>): void {
     onChange(event.currentTarget.checked)
   }
@@ -27,6 +30,7 @@ export default function Toggle({
 
   const inputClasses = classNames(inputClassName, 'relative', {
     [defaultInputStyle]: !reset,
+    [invertInputStyle(invert)]: invert && !reset,
   })
 
   return (
@@ -49,10 +53,10 @@ export default function Toggle({
           }}
         />
         <div
-          className="absolute center-vertical bg-white br-100 top-0 bottom-0 pointer-events-none"
+          className={`absolute w1 h1 center-vertical
+           ${invert || 'bg-white'}
+           br-100 top-0 bottom-0 pointer-events-none`}
           style={{
-            width: 16,
-            height: 16,
             transition: 'left 0.2s',
             left: checked ? 20 : 2,
           }}

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -6,7 +6,8 @@ const disabledStyle = 'o-30 pointer-events-none'
 const inactiveStyle = 'o-50'
 const defaultInputStyle = 'br4 bg-black'
 
-const invertInputStyle = (invert: string) => `ba br4 bg-transparent b--${invert.replace(/bg-/, '')}`
+const invertInputStyle = (invertColor: string) =>
+  `ba br4 bg-transparent b--${invertColor.replace(/bg-/, '')}`
 
 export const Toggle: React.SFC<InputPropsTypes> = ({
   children,
@@ -17,7 +18,7 @@ export const Toggle: React.SFC<InputPropsTypes> = ({
   checked = false,
   onChange = () => {},
   reset = false,
-  invert = '',
+  invertColor = '',
 }) => {
   function handleChange(event: React.ChangeEvent<HTMLInputElement>): void {
     onChange(event.currentTarget.checked)
@@ -30,7 +31,7 @@ export const Toggle: React.SFC<InputPropsTypes> = ({
 
   const inputClasses = classNames(inputClassName, 'relative', {
     [defaultInputStyle]: !reset,
-    [invertInputStyle(invert)]: invert && !reset,
+    [invertInputStyle(invertColor)]: invertColor && !reset,
   })
 
   return (
@@ -54,7 +55,7 @@ export const Toggle: React.SFC<InputPropsTypes> = ({
         />
         <div
           className={`absolute w1 h1 center-vertical
-           ${invert || 'bg-white'}
+           ${invertColor || 'bg-white'}
            br-100 top-0 bottom-0 pointer-events-none`}
           style={{
             transition: 'left 0.2s',


### PR DESCRIPTION
Add the prop `(invert: string)`; one can pass to it the background color in a tachyonish manner, and the toggle will have the background color set to transparent and the border around the `<input />` and the color of the toggle pin of the value pass through the prop.

Some minor changes regard the way the component is declared, not a simple function but an arrow function of type `React.SFC`
I have removed also the inline style for the toggle pin, in favor of two tachyons classes, so instead of `style={{ width: '16px', height: '16px' }}, I just added `w1 h1` in the className prop.