### PR TITLE
Svgprop checkbox bug

### DIFF
--- a/lib/lib/src/components/Checkbox/index.d.ts
+++ b/lib/lib/src/components/Checkbox/index.d.ts
@@ -5,7 +5,7 @@ interface SVGProps {
     style?: React.CSSProperties;
 }
 export interface CheckBoxArguments extends InputPropsTypes {
-    propSvg: React.SFC<SVGProps> | null;
+    propSvg?: React.SFC<SVGProps>;
 }
 export default function Checkbox({ children, propSvg, className, inputClassName, style, disabled, checked, onChange, reset, ...props }: CheckBoxArguments): JSX.Element;
 export {};

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -26,7 +26,7 @@ interface SVGProps {
 }
 
 export interface CheckBoxArguments extends InputPropsTypes {
-  propSvg: React.SFC<SVGProps> | null // TODO
+  propSvg?: React.SFC<SVGProps>
 }
 
 export default function Checkbox({


### PR DESCRIPTION
Small bug fix where I defined `propSvg: React.SFC<SVGProps> | null` instead of `propSvg?: React.SFC<SVGProps>` in the props interface. 

Try the fix with `yarn add @accurat/react-components@accurat/react-components#svgprop-checkbox-bug`