### PR TITLE
Resolving #27 

### DIFF
--- a/lib/lib/src/commons/interfaces.d.ts
+++ b/lib/lib/src/commons/interfaces.d.ts
@@ -1,4 +1,7 @@
 /// <reference types="react" />
+export declare type BooleanChangeFunction = (event: boolean) => void;
+export declare type InputChangeFunction = (event: React.ChangeEvent<HTMLInputElement>) => void;
+declare type OnChangeFunction = BooleanChangeFunction | InputChangeFunction;
 export interface InputPropsTypes {
     children?: React.ReactNode;
     className?: string;
@@ -6,7 +9,8 @@ export interface InputPropsTypes {
     style?: object;
     disabled?: boolean;
     checked?: boolean;
-    onChange?: (event: boolean) => void;
+    onChange?: OnChangeFunction;
     reset?: boolean;
 }
 export declare const InputDefaultProps: object;
+export {};

--- a/lib/lib/src/commons/interfaces.d.ts
+++ b/lib/lib/src/commons/interfaces.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
-export declare type BooleanChangeFunction = (event: boolean) => void;
-export declare type InputChangeFunction = (event: React.ChangeEvent<HTMLInputElement>) => void;
-declare type OnChangeFunction = BooleanChangeFunction | InputChangeFunction;
+export declare type BooleanChangeFnType = (event: boolean) => void;
+export declare type InputChangeFnType = (event: React.ChangeEvent<HTMLInputElement>) => void;
+declare type OnChangeFunction = BooleanChangeFnType | InputChangeFnType;
 export interface InputPropsTypes {
     children?: React.ReactNode;
     className?: string;

--- a/lib/lib/src/components/Checkbox/index.d.ts
+++ b/lib/lib/src/components/Checkbox/index.d.ts
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { InputPropsTypes } from '../../commons/interfaces';
+import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces';
 interface SVGProps {
     className?: string;
     style?: React.CSSProperties;
 }
 export interface CheckBoxArguments extends InputPropsTypes {
     propSvg?: React.SFC<SVGProps>;
+    onChange?: BooleanChangeFunction;
 }
 export default function Checkbox({ children, propSvg, className, inputClassName, style, disabled, checked, onChange, reset, ...props }: CheckBoxArguments): JSX.Element;
 export {};

--- a/lib/lib/src/components/Checkbox/index.d.ts
+++ b/lib/lib/src/components/Checkbox/index.d.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces';
+import { InputPropsTypes, BooleanChangeFnType } from '../../commons/interfaces';
 interface SVGProps {
     className?: string;
     style?: React.CSSProperties;
 }
 export interface CheckBoxArguments extends InputPropsTypes {
     propSvg?: React.SFC<SVGProps>;
-    onChange?: BooleanChangeFunction;
+    onChange?: BooleanChangeFnType;
 }
 export default function Checkbox({ children, propSvg, className, inputClassName, style, disabled, checked, onChange, reset, ...props }: CheckBoxArguments): JSX.Element;
 export {};

--- a/lib/lib/src/components/Radio/index.d.ts
+++ b/lib/lib/src/components/Radio/index.d.ts
@@ -1,5 +1,5 @@
-import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces';
+import { InputPropsTypes, BooleanChangeFnType } from '../../commons/interfaces';
 export interface RadioProps extends InputPropsTypes {
-    onChange?: BooleanChangeFunction;
+    onChange?: BooleanChangeFnType;
 }
 export default function Radio({ children, className, inputClassName, style, disabled, checked, onChange, reset, ...props }: RadioProps): JSX.Element;

--- a/lib/lib/src/components/Radio/index.d.ts
+++ b/lib/lib/src/components/Radio/index.d.ts
@@ -1,2 +1,5 @@
-import { InputPropsTypes } from '../../commons/interfaces';
-export default function Radio({ children, className, inputClassName, style, disabled, checked, onChange, reset, ...props }: InputPropsTypes): JSX.Element;
+import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces';
+export interface RadioProps extends InputPropsTypes {
+    onChange?: BooleanChangeFunction;
+}
+export default function Radio({ children, className, inputClassName, style, disabled, checked, onChange, reset, ...props }: RadioProps): JSX.Element;

--- a/lib/lib/src/components/Select/index.d.ts
+++ b/lib/lib/src/components/Select/index.d.ts
@@ -21,6 +21,7 @@ export default class Select extends React.Component<SelectProps> {
     componentWillUnmount(): void;
     static defaultProps: {
         autoclose: boolean;
+        childrenClassName: string;
     };
     state: {
         open: boolean;
@@ -29,7 +30,7 @@ export default class Select extends React.Component<SelectProps> {
     setClose: () => void;
     setOpen: () => void;
     toogleOpen: () => void;
-    handleClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+    handleClick: (event: React.MouseEvent<HTMLDivElement>) => void;
     handleOutsideClick: (event: MouseEvent) => void;
     render(): JSX.Element;
 }

--- a/lib/lib/src/components/Select/index.d.ts
+++ b/lib/lib/src/components/Select/index.d.ts
@@ -21,7 +21,6 @@ export default class Select extends React.Component<SelectProps> {
     componentWillUnmount(): void;
     static defaultProps: {
         autoclose: boolean;
-        childrenClassName: string;
     };
     state: {
         open: boolean;

--- a/lib/lib/src/components/TextInput/index.d.ts
+++ b/lib/lib/src/components/TextInput/index.d.ts
@@ -1,12 +1,12 @@
-import * as React from 'react';
-export interface TextInputpropsType {
+import { InputPropsTypes, InputChangeFunction } from 'src/commons/interfaces';
+export interface TextInputpropsType extends InputPropsTypes {
     className?: string;
     style?: object;
     type?: 'text' | 'email' | 'password' | 'number' | 'tel' | 'time' | 'date' | 'datetime-local';
     value?: string | number;
     defaultValue?: string;
     disabled?: boolean;
-    onChange?: (event?: React.ChangeEvent<HTMLInputElement>) => void;
+    onChange?: InputChangeFunction;
     checkValidity?: (cond: boolean) => void;
     reset?: boolean;
 }

--- a/lib/lib/src/components/TextInput/index.d.ts
+++ b/lib/lib/src/components/TextInput/index.d.ts
@@ -1,13 +1,9 @@
-import { InputPropsTypes, InputChangeFunction } from 'src/commons/interfaces';
+import { InputPropsTypes, InputChangeFnType } from 'src/commons/interfaces';
 export interface TextInputpropsType extends InputPropsTypes {
-    className?: string;
-    style?: object;
+    onChange?: InputChangeFnType;
     type?: 'text' | 'email' | 'password' | 'number' | 'tel' | 'time' | 'date' | 'datetime-local';
     value?: string | number;
     defaultValue?: string;
-    disabled?: boolean;
-    onChange?: InputChangeFunction;
     checkValidity?: (cond: boolean) => void;
-    reset?: boolean;
 }
 export default function TextInput({ value, defaultValue, className, style, type, onChange, checkValidity, reset, disabled, ...props }: TextInputpropsType): JSX.Element;

--- a/lib/lib/src/components/Toggle/index.d.ts
+++ b/lib/lib/src/components/Toggle/index.d.ts
@@ -1,2 +1,6 @@
-import { InputPropsTypes } from '../../commons/interfaces';
-export default function Toggle({ children, className, inputClassName, style, disabled, checked, onChange, reset, }: InputPropsTypes): JSX.Element;
+import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces';
+interface ToggleProps extends InputPropsTypes {
+    onChange?: BooleanChangeFunction;
+}
+export default function Toggle({ children, className, inputClassName, style, disabled, checked, onChange, reset, }: ToggleProps): JSX.Element;
+export {};

--- a/lib/lib/src/components/Toggle/index.d.ts
+++ b/lib/lib/src/components/Toggle/index.d.ts
@@ -1,6 +1,6 @@
-import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces';
+import { InputPropsTypes, BooleanChangeFnType } from '../../commons/interfaces';
 interface ToggleProps extends InputPropsTypes {
-    onChange?: BooleanChangeFunction;
+    onChange?: BooleanChangeFnType;
 }
 export default function Toggle({ children, className, inputClassName, style, disabled, checked, onChange, reset, }: ToggleProps): JSX.Element;
 export {};

--- a/lib/react-components.js
+++ b/lib/react-components.js
@@ -12340,7 +12340,7 @@ var Select_Select = /** @class */ (function (_super) {
                 return (external_root_React_commonjs2_react_commonjs_react_amd_react_["createElement"]("div", { key: i, onClick: autoclose ? _this.setClose : null }, child));
             })))));
     };
-    Select.defaultProps = Select_assign({}, InputDefaultProps, { autoclose: true, childrenClassName: '' });
+    Select.defaultProps = Select_assign({}, InputDefaultProps, { autoclose: true });
     return Select;
 }(external_root_React_commonjs2_react_commonjs_react_amd_react_["Component"]));
 /* harmony default export */ var components_Select = (Select_Select);

--- a/lib/react-components.js
+++ b/lib/react-components.js
@@ -12340,7 +12340,7 @@ var Select_Select = /** @class */ (function (_super) {
                 return (external_root_React_commonjs2_react_commonjs_react_amd_react_["createElement"]("div", { key: i, onClick: autoclose ? _this.setClose : null }, child));
             })))));
     };
-    Select.defaultProps = Select_assign({}, InputDefaultProps, { autoclose: true });
+    Select.defaultProps = Select_assign({}, InputDefaultProps, { autoclose: true, childrenClassName: '' });
     return Select;
 }(external_root_React_commonjs2_react_commonjs_react_amd_react_["Component"]));
 /* harmony default export */ var components_Select = (Select_Select);

--- a/src/commons/interfaces.ts
+++ b/src/commons/interfaces.ts
@@ -1,9 +1,9 @@
 import { noop } from 'lodash'
 
-export type BooleanChangeFunction = (event: boolean) => void
-export type InputChangeFunction = (event: React.ChangeEvent<HTMLInputElement>) => void
+export type BooleanChangeFnType = (event: boolean) => void
+export type InputChangeFnType = (event: React.ChangeEvent<HTMLInputElement>) => void
 
-type OnChangeFunction = BooleanChangeFunction | InputChangeFunction
+type OnChangeFunction = BooleanChangeFnType | InputChangeFnType
 
 export interface InputPropsTypes {
   children?: React.ReactNode

--- a/src/commons/interfaces.ts
+++ b/src/commons/interfaces.ts
@@ -1,5 +1,10 @@
 import { noop } from 'lodash'
 
+export type BooleanChangeFunction = (event: boolean) => void
+export type InputChangeFunction = (event: React.ChangeEvent<HTMLInputElement>) => void
+
+type OnChangeFunction = BooleanChangeFunction | InputChangeFunction
+
 export interface InputPropsTypes {
   children?: React.ReactNode
   className?: string
@@ -7,7 +12,7 @@ export interface InputPropsTypes {
   style?: object
   disabled?: boolean
   checked?: boolean
-  onChange?: (event: boolean) => void // This has to be fixed
+  onChange?: OnChangeFunction
   reset?: boolean
 }
 

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces'
+import { InputPropsTypes, BooleanChangeFnType } from '../../commons/interfaces'
 
 const disabledStyle = 'o-30 pointer-events-none'
 const inactiveStyle = 'o-50'
@@ -27,7 +27,7 @@ interface SVGProps {
 
 export interface CheckBoxArguments extends InputPropsTypes {
   propSvg?: React.SFC<SVGProps>
-  onChange?: BooleanChangeFunction
+  onChange?: BooleanChangeFnType
 }
 
 export default function Checkbox({

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import { InputPropsTypes } from '../../commons/interfaces'
+import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces'
 
 const disabledStyle = 'o-30 pointer-events-none'
 const inactiveStyle = 'o-50'
@@ -27,6 +27,7 @@ interface SVGProps {
 
 export interface CheckBoxArguments extends InputPropsTypes {
   propSvg?: React.SFC<SVGProps>
+  onChange?: BooleanChangeFunction
 }
 
 export default function Checkbox({

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import { InputPropsTypes } from '../../commons/interfaces'
+import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces'
 
 const disabledStyle = 'o-30 pointer-events-none'
 const inactiveStyle = 'o-50'
 const defaultInputStyle = 'bw1 b--black bg-black outline-transparent'
+
+export interface RadioProps extends InputPropsTypes {
+  onChange?: BooleanChangeFunction
+}
 
 export default function Radio({
   children,
@@ -16,7 +20,7 @@ export default function Radio({
   onChange = () => {},
   reset = false,
   ...props
-}: InputPropsTypes): JSX.Element {
+}: RadioProps): JSX.Element {
   function handleChange(event: React.ChangeEvent<HTMLInputElement>): void {
     onChange(event.currentTarget.checked)
   }

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces'
+import { InputPropsTypes, BooleanChangeFnType } from '../../commons/interfaces'
 
 const disabledStyle = 'o-30 pointer-events-none'
 const inactiveStyle = 'o-50'
 const defaultInputStyle = 'bw1 b--black bg-black outline-transparent'
 
 export interface RadioProps extends InputPropsTypes {
-  onChange?: BooleanChangeFunction
+  onChange?: BooleanChangeFnType
 }
 
 export default function Radio({

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -48,7 +48,7 @@ export default class Select extends React.Component<SelectProps> {
     document.body.removeEventListener('touchend', this.handleOutsideClick)
   }
 
-  static defaultProps = { ...InputDefaultProps, autoclose: true, childrenClassName: '' }
+  static defaultProps = { ...InputDefaultProps, autoclose: true }
   state = { open: this.props.open }
   container: HTMLDivElement = null
 

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -6,15 +6,11 @@ const disabledStyle = 'o-50 pointer-events-none'
 const defaultStyle = 'b--black black bg-white'
 
 export interface TextInputpropsType extends InputPropsTypes {
-  className?: string
-  style?: object
+  onChange?: InputChangeFunction
   type?: 'text' | 'email' | 'password' | 'number' | 'tel' | 'time' | 'date' | 'datetime-local'
   value?: string | number
   defaultValue?: string
-  disabled?: boolean
-  onChange?: InputChangeFunction
   checkValidity?: (cond: boolean) => void
-  reset?: boolean
 }
 
 const handleChange = (

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
 import classNames from 'classnames'
+import { InputPropsTypes } from 'src/commons/interfaces'
 
 const disabledStyle = 'o-50 pointer-events-none'
 const defaultStyle = 'b--black black bg-white'
 
-export interface TextInputpropsType {
+export interface TextInputpropsType extends InputPropsTypes {
   className?: string
   style?: object
   type?: 'text' | 'email' | 'password' | 'number' | 'tel' | 'time' | 'date' | 'datetime-local'

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import { InputPropsTypes } from 'src/commons/interfaces'
+import { InputPropsTypes, InputChangeFunction } from 'src/commons/interfaces'
 
 const disabledStyle = 'o-50 pointer-events-none'
 const defaultStyle = 'b--black black bg-white'
@@ -12,7 +12,7 @@ export interface TextInputpropsType extends InputPropsTypes {
   value?: string | number
   defaultValue?: string
   disabled?: boolean
-  onChange?: (event?: React.ChangeEvent<HTMLInputElement>) => void
+  onChange?: InputChangeFunction
   checkValidity?: (cond: boolean) => void
   reset?: boolean
 }

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import { InputPropsTypes, InputChangeFunction } from 'src/commons/interfaces'
+import { InputPropsTypes, InputChangeFnType } from 'src/commons/interfaces'
 
 const disabledStyle = 'o-50 pointer-events-none'
 const defaultStyle = 'b--black black bg-white'
 
 export interface TextInputpropsType extends InputPropsTypes {
-  onChange?: InputChangeFunction
+  onChange?: InputChangeFnType
   type?: 'text' | 'email' | 'password' | 'number' | 'tel' | 'time' | 'date' | 'datetime-local'
   value?: string | number
   defaultValue?: string

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces'
+import { InputPropsTypes, BooleanChangeFnType } from '../../commons/interfaces'
 
 interface ToggleProps extends InputPropsTypes {
-  onChange?: BooleanChangeFunction
+  onChange?: BooleanChangeFnType
 }
 
 const disabledStyle = 'o-30 pointer-events-none'

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import { InputPropsTypes } from '../../commons/interfaces'
+import { InputPropsTypes, BooleanChangeFunction } from '../../commons/interfaces'
+
+interface ToggleProps extends InputPropsTypes {
+  onChange?: BooleanChangeFunction
+}
 
 const disabledStyle = 'o-30 pointer-events-none'
 const inactiveStyle = 'o-50'
@@ -15,7 +19,7 @@ export default function Toggle({
   checked = false,
   onChange = () => {},
   reset = false,
-}: InputPropsTypes): JSX.Element {
+}: ToggleProps): JSX.Element {
   function handleChange(event: React.ChangeEvent<HTMLInputElement>): void {
     onChange(event.currentTarget.checked)
   }


### PR DESCRIPTION
A few changes in the typing in order to resolve #27. The basic idea is to abstract the typing and interfaces from the single components to the interface file. This approach allows later to expand with other `onChange` functions and keep the typing. 

