### PR TITLE
🐞 fix handleClickOutside check: ref was in wrong div

### DIFF
--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -96,12 +96,14 @@ export class Select extends React.Component<SelectProps> {
     const Icon = customIcon || DownIcon
 
     return (
-      <div className="relative">
+      <div
+        className="relative"
+        ref={el => {
+          this.container = el
+        }}
+      >
         <div
           {...props}
-          ref={el => {
-            this.container = el
-          }}
           onClick={this.handleClick}
           className={`${className} relative`}
           style={style}


### PR DESCRIPTION
**Please check the type of change your PR introduces:**
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring / Code style update (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other (please describe): 


**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

Prevent autoclosing wasn't working beacause container ref was on wrong div: select options never were container children.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
