### PR TITLE
Select: add listener to body only when select is open

### DIFF
--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -25,18 +25,24 @@ export interface SelectProps {
 }
 
 export class Select extends React.Component<SelectProps> {
-  componentDidMount() {
-    document.body.addEventListener('mouseup', this.handleOutsideClick, {
-      passive: true,
-    })
-    document.body.addEventListener('touchend', this.handleOutsideClick, {
-      passive: true,
-    })
+  onOpen() {
+    document.body.addEventListener('mouseup', this.handleOutsideClick, { passive: true })
+    document.body.addEventListener('touchend', this.handleOutsideClick, { passive: true })
   }
 
-  componentWillUnmount() {
+  onClose() {
     document.body.removeEventListener('mouseup', this.handleOutsideClick)
     document.body.removeEventListener('touchend', this.handleOutsideClick)
+  }
+
+  componentDidUpdate(prevProps: SelectProps, prevState: any) {
+    if (prevState.open !== this.state.open) {
+      if (this.state.open) {
+        this.onOpen()
+      } else {
+        this.onClose()
+      }
+    }
   }
 
   static defaultProps = {


### PR DESCRIPTION
Add `this.handleOutsideClick` listener only when select is open. This improves page performance when there are many select mounted.